### PR TITLE
feat: init commands for networks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,8 @@ on:
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/docker.yml"
+    paths-ignore:
+      - '**/*.md'
     tags:
       - "v*"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN pnpm run build
 # Stage 2: Production image
 FROM base AS runner
 
+# install deps used by scripts
+RUN apk add --no-cache \
+  bash \
+  netcat-openbsd
+
 COPY --from=builder /app/appchain/packages/chain/dist /app/appchain/packages/chain/dist
 COPY --from=builder /app/appchain/packages/chain/package.json /app/appchain/packages/chain/
 COPY --from=builder /app/appchain/package.json /app/appchain/pnpm-lock.yaml /app/appchain/
@@ -35,5 +40,7 @@ RUN --mount=type=cache,id=pnpm,target=${PNPM_HOME}/store cd /app/appchain && pnp
 COPY --from=builder /app/appchain-agent/dist ./dist
 COPY --from=builder /app/appchain-agent/package.json /app/appchain-agent/pnpm-lock.yaml ./
 RUN --mount=type=cache,id=pnpm,target=${PNPM_HOME}/store pnpm install --prod --frozen-lockfile
+
+COPY bin ./bin
 
 USER node

--- a/bin/network-init.sh
+++ b/bin/network-init.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+test -z "${2}" && echo "USAGE: ${0} <network_id> <file://build.yml> [data dir]" && exit 1
+
+network_id=${1}
+network_build=${2}
+dir=${3:-/tmp}
+socket=${dir}/appchain.sock
+
+cat <<EOF
+Initialize Network:
+  data directory: '${dir}'
+  network id: '${network_id}'
+  network build file: '${network_build}'
+EOF
+
+mkdir -p "${dir}"
+
+node \
+  --experimental-specifier-resolution=node \
+  --experimental-vm-modules \
+  --experimental-wasm-modules \
+  --experimental-wasm-threads \
+  --no-warnings \
+  dist/index.js \
+  --admin \
+  --debug \
+  --ipfs \
+  --ipfs-data ${dir}/ipfs \
+  --key ${dir}/admin.key \
+  --listen \
+  --nonce \
+  --socket ${socket} \
+  --tx-status-retries 0 \
+  &
+PID=$!
+
+# Wait for the socket to exist
+while [ ! -S ${socket} ]; do sleep 1; done
+
+appchain () {
+  echo "$@" | tee >(cat >&2) | nc -U -q 0 ${socket}
+  sleep 0.2s
+}
+
+appchain admin setAdmin
+appchain nodes setRegistrationStake 0
+appchain nodes openRegistration
+appchain networks register ${network_id} ${network_build}
+sleep 1s # avoid nonce collision from slower register command (IPFS)
+appchain networks setActive ${network_id}
+
+kill ${PID}
+
+rm -f ${socket}

--- a/clients/go/chainbridge/chainbridge.go
+++ b/clients/go/chainbridge/chainbridge.go
@@ -51,6 +51,11 @@ type CommandResponse struct {
 	TX     string      `cbor:"tx,omitempty"`
 }
 
+type Network struct {
+	Identifier string `cbor:"identifier"`
+	Parameters []byte `cbor:"parameters"`
+}
+
 type Node struct {
 	Administrator string `cbor:"administrator"`
 	Identifier    string `cbor:"identifier"`
@@ -65,11 +70,14 @@ var (
 	ErrNoData = errors.New("ChainBridge: no data")
 
 	// command response errors returned by the appchain
-	Err_nodes_alreadyRegistered = "Node already registered"
+	Err_networks_alreadyRegistered = "Network already registered"
+	Err_nodes_alreadyRegistered    = "Node already registered"
 )
 
 // appchain-agent commands; cuz compile errors are better than runtime errors
 var (
+	Cmd_networks_getNetwork         = "networks getNetwork %s"
+	Cmd_networks_register           = "networks register %s"
 	Cmd_nodes_getNode               = "nodes getNode %s"
 	Cmd_nodes_register              = "nodes register %s %d %d"
 	Cmd_pki_getDocucment            = "pki getDocument %d"

--- a/clients/go/cmd/client/main.go
+++ b/clients/go/cmd/client/main.go
@@ -71,7 +71,7 @@ func nodeRegistration() {
 
 	// register the node
 	command := fmt.Sprintf(
-		"nodes register %s %d %d",
+		chainbridge.Cmd_nodes_register,
 		node1.Identifier,
 		chainbridge.Bool2int(node1.IsGatewayNode),
 		chainbridge.Bool2int(node1.IsServiceNode))
@@ -85,7 +85,7 @@ func nodeRegistration() {
 	}
 
 	// retrieve the node
-	command = fmt.Sprintf("nodes getNode %s", node1.Identifier)
+	command = fmt.Sprintf(chainbridge.Cmd_nodes_getNode, node1.Identifier)
 	response, err = chBridge.Command(command, nil)
 	if err != nil {
 		log.Printf("ChainBridge command error: %v", err)
@@ -125,7 +125,7 @@ func pkiMixDescriptor() {
 	id := "node-5000"
 
 	// send encoded data as payload to IPFS and the appchain
-	command := fmt.Sprintf("pki setMixDescriptor %d %s", epoch, id)
+	command := fmt.Sprintf(chainbridge.Cmd_pki_setMixDescriptor, epoch, id)
 	response, err := chBridge.Command(command, enc)
 	log.Printf("Response (%s): %+v\n", command, response)
 	if err != nil {
@@ -136,7 +136,7 @@ func pkiMixDescriptor() {
 	}
 
 	// retrieve the stored data
-	command = fmt.Sprintf("pki getMixDescriptor %d %s", epoch, id)
+	command = fmt.Sprintf(chainbridge.Cmd_pki_getMixDescriptor, epoch, id)
 	response, err = chBridge.Command(command, nil)
 	if err != nil {
 		log.Printf("ChainBridge command error: %v", err)
@@ -158,8 +158,7 @@ func pkiMixDescriptor() {
 }
 
 func getGenesisEpoch() uint64 {
-	command := "pki getGenesisEpoch"
-	response, err := chBridge.Command(command, nil)
+	response, err := chBridge.Command(chainbridge.Cmd_pki_getGenesisEpoch, nil)
 	if err != nil {
 		log.Printf("ChainBridge command error: %v", err)
 	}

--- a/clients/go/cmd/client/main.go
+++ b/clients/go/cmd/client/main.go
@@ -24,6 +24,42 @@ func sendCommand(command string, payload []byte) {
 	}
 }
 
+func networkRegistration() {
+	network1 := chainbridge.Network{
+		Identifier: "0x000",
+		Parameters: []byte("pA: 1\npB: 2\npC: 3\n"),
+	}
+	log.Printf("Network in: %+v", network1)
+
+	// register the network
+	command := fmt.Sprintf(
+		chainbridge.Cmd_networks_register,
+		network1.Identifier,
+	)
+	response, err := chBridge.Command(command, network1.Parameters)
+	log.Printf("Response (%s): %+v\n", command, response)
+	if err != nil {
+		log.Printf("ChainBridge command error: %v", err)
+	}
+	if response.Error != "" {
+		log.Printf("ChainBridge response error: %v", response.Error)
+	}
+
+	// retrieve the network
+	command = fmt.Sprintf(chainbridge.Cmd_networks_getNetwork, network1.Identifier)
+	response, err = chBridge.Command(command, nil)
+	if err != nil {
+		log.Printf("ChainBridge command error: %v", err)
+	} else {
+		log.Printf("Response (%s): %+v\n", command, response)
+	}
+	var network2 chainbridge.Network
+	if err := chBridge.DataUnmarshal(response, &network2); err != nil {
+		log.Printf("ChainBridge data error: %v", err)
+	}
+	log.Printf("Network out: %+v", network2)
+}
+
 func nodeRegistration() {
 	node1 := chainbridge.Node{
 		Identifier:    "node-5000",
@@ -186,6 +222,7 @@ func main() {
 	}
 	wg.Wait()
 
+	networkRegistration()
 	nodeRegistration()
 
 	log.Printf("genesisEpoch: %d", getGenesisEpoch())

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "eslint .",
     "build": "tsc -p tsconfig.json",
-    "agent": "node --experimental-specifier-resolution=node --experimental-vm-modules --experimental-wasm-modules --experimental-wasm-threads dist/index.js"
+    "agent": "node --experimental-specifier-resolution=node --experimental-vm-modules --experimental-wasm-modules --experimental-wasm-threads --no-warnings dist/index.js"
   },
   "devDependencies": {
     "@types/node": "^22.4.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -362,10 +362,24 @@ const executeCommand = async (
     });
   commandNetworks
     .command("getNetwork <identifier> [file://]")
-    .description("get network by identifier; optionally save params to file")
+    .description(
+      'get network by id; "_" for active, optionally save params to file',
+    )
     .action(async (identifier: string, file?: string) => {
       if (!ipfsNode) return callback(responses.IPFS_NOT_STARTED);
-      const networkID = Network.getID(CircuitString.fromString(identifier));
+
+      var networkID: Field;
+      if (identifier === "_") {
+        const nid =
+          (await client.query.runtime.Networks.activeNetwork.get()) as
+            | Field
+            | undefined;
+        if (!nid) return callback(responses.RECORD_NOT_FOUND);
+        networkID = nid;
+      } else {
+        networkID = Network.getID(CircuitString.fromString(identifier));
+      }
+
       const network = (await client.query.runtime.Networks.networks.get(
         networkID,
       )) as Network | undefined;


### PR DESCRIPTION
Includes a `bin/network-init.sh` bash script that is included in the docker image to initialize a network; set admin, register network (with it's parameters build.yml), and set it as active. Nodes are then able to retrieve the network info from the appchain to self-generate their compatible configuration with the network.